### PR TITLE
feed_contact_email

### DIFF
--- a/reference/gtfs.md
+++ b/reference/gtfs.md
@@ -149,7 +149,7 @@ feed_lang | Required | Included |
 feed_start_date | Optional | Included | When comparing two GTFS feeds, the newer one will always have a newer `feed_start_date`.
 feed_end_date | Optional | Included |
 feed_version | Optional | Included | 
-feed_contact_email | Experimental | Included | An email address for communication regarding the GTFS dataset and data publishing practices. It is a technical contact for GTFS-consuming applications. Provide customer service contact information through [agency.txt](agencytxt).
+feed_contact_email | Optional | Included | An email address for communication regarding the GTFS dataset and data publishing practices. It is a technical contact for GTFS-consuming applications. Provide customer service contact information through [agency.txt](agencytxt).
 
 ## frequencies.txt
 

--- a/reference/gtfs.md
+++ b/reference/gtfs.md
@@ -145,12 +145,11 @@ Field Name | GTFS spec | Status | Notes
 ---------- | -------- | ------ | ------
 feed_publisher_name | Required | Included | 
 feed_publisher_url | Required | Included | 
-feed_contact_url | Experimental | Included | 
-feed_contact_email | Experimental | Included | 
 feed_lang | Required | Included | 
 feed_start_date | Optional | Included | When comparing two GTFS feeds, the newer one will always have a newer `feed_start_date`.
 feed_end_date | Optional | Included |
 feed_version | Optional | Included | 
+feed_contact_email | Experimental | Included | An email address for communication regarding the GTFS dataset and data publishing practices. It is a technical contact for GTFS-consuming applications. Provide customer service contact information through [agency.txt](agencytxt).
 
 ## frequencies.txt
 


### PR DESCRIPTION
Removes the feed_contact_url field because we won't use it.