### PR TITLE
Populate shape_dist_traveled in shapes.txt

### DIFF
--- a/reference/gtfs.md
+++ b/reference/gtfs.md
@@ -285,7 +285,7 @@ shape_id | Required | Included |
 shape_pt_lat | Required | Included | 
 shape_pt_lon | Required | Included | 
 shape_pt_sequence | Required | Included | 
-shape_dist_traveled | Optional | Included (empty) | 
+shape_dist_traveled | Optional | Included | Distances reported in meters.
 
 ## stops.txt
 


### PR DESCRIPTION
Field is being used in shapes.txt in MBTA GTFS as of January 17, 2019.