### PR TITLE
Populate zone_id in stops.txt for Commuter Rail

### DIFF
--- a/reference/gtfs.md
+++ b/reference/gtfs.md
@@ -287,7 +287,7 @@ platform_code | Experimental | Included (some records) | Indicates the platform 
 platform_name | Experimental | Included (some records) | Indicates the platform name as labeled at a station, often indicating the direction or destination of services passing through a platform. Words like "platform" or "track" (or the feed's language-specific equivalent) should not be included.<br><br>For example, the platform toward Ashmont and Braintree on the Red Line at Park Street will have a `platform_name` of `Ashmont/Braintree`.
 stop_lat | Required | Included | Children stops with a `parent_station` may have different `stop_lat` value as that of the parent.
 stop_lon | Required | Included | Children stops with a `parent_station` may have different `stop_lon` value as that of the parent.
-zone_id | Optional | Included (empty) | 
+zone_id | Optional | Included (some records) | Populated with Commuter Rail fare zone information at Commuter Rail stations and stops. Special values may be applied at stations at which multiple fare zones or where special event fares are in effect.
 stop_address | Experimental | Included (some records) | Optional field which allows a stop to have included a human-readable address.
 stop_url | Optional | Included (some records) | Populated for stops which are not entrances, as defined by having a `location_type` of `2`.
 level_id | Experimental | Included (some records) | Reference to vertical station level from [levels.txt](#levelstxt).


### PR DESCRIPTION
`zone_id`s will be populated for Commuter Rail stops in the coming week. Values will typically be in the form of `CR-zone-1A`, `CR-zone-1`, etc, with special handling for stations where multiple fare zones may temporarily apply (Quincy Center as `CR-zone-1A-1`), and where special event fares will be in effect (Foxboro as `CR-zone-special`).

**Sample of full stops file after `zone_id` is populated for Commuter Rail service stops: [stops.txt](https://github.com/mbta/gtfs-documentation/files/3076851/stops.txt)**
