### PR TITLE
municipality, on_street, at_street, vehicle_type in stops.txt

### DIFF
--- a/reference/gtfs.md
+++ b/reference/gtfs.md
@@ -309,6 +309,10 @@ location_type | Optional | Included | A value of `1` indicates a parent station 
 parent_station | Optional | Included (some records) | For stops location within stations, the `parent_station`'s `stop_id` represents the whole facility and the child stop represents a specific boarding area, entrance, or generic node.<br><br>All subway, Commuter Rail, and CapeFLYER stops have a parent station, as do some bus and Silver Line facilities, such as Dudley.
 stop_timezone | Optional | N/A | 
 wheelchair_boarding | Optional | Included | Additional guidance for bus stops only:<ul><li>`0`: Minor to moderate accessibility barriers exist at the stop. Bus operator may need to relocate bus for safe boarding and exiting.</li><li>`2`: Significant accessibility barriers exist at the stop. Customers using wheeled mobility devices may need to board at street level.</li></ul>
+municipality | Experimental | Included (some records) | Lists the name of the city or town in which the stop is located.
+on_street | Experimental | Included (some records) | Provides the full name of the street along which a stop is located. Populated for most, but not all, bus stops. Not currently populated for rail or ferry stops, nor for stops with `location_type` not equal to `0`.
+at_street | Experimental | Included (some records) | Provides the full name of a stop's nearest cross street. Populated for most, but not all, bus stops. Note that `at_street` will not be populated unless `on_street` is also populated.
+vehicle_type | Experimental | Included (some records) | Part of the [Google Transit Extensions to GTFS](https://developers.google.com/transit/gtfs/reference/gtfs-extensions). Describes the mode of transportation used at the stop. Populated for all stops where `location_type` equals `0`, including those which do not have service scheduled in advance. Value definitions match those for `route_type`; for example, the stop `Alewife-02` has a `vehicle_type` of `1`, which defines it as a subway stop.
 
 ## stop_times.txt
 


### PR DESCRIPTION
Introduces **four new fields** into `stops.txt` which provide more specific and parsable information about where our stops are located, and about what mode of service can be expected at stops:
- `municipality`
- `on_street`
- `at_street`
- `vehicle_type`

These new files will be introduced into the MBTA's GTFS-static file on **Thursday, June 27, 2019**.