### PR TITLE
Allow empty values for signposted_as in pathways.txt

### DIFF
--- a/reference/gtfs.md
+++ b/reference/gtfs.md
@@ -239,7 +239,7 @@ stair_count | Optional | Included (some records) | Number of stairs required to 
 max_slope | Optional | Included (some records) | Will be populated and non-zero for sloped pathways.
 pathway_name | Experimental | Included | Contains description of the path origin and destination.
 pathway_code | Experimental | Included (empty) |
-signposted_as | Optional | Included | Contains indication of the path destination as it is signed at the particular station.
+signposted_as | Optional | Included (some records) | Contains indication of the path destination as it is signed at the particular station. If no such signage exists, the field will be blank.
 instructions | Experimental | Included (empty) |
 
 ## routes.txt


### PR DESCRIPTION
Specifies that the field `signposted_as` will no longer be populated for all rows in the `pathways.txt` file. The field will only be populated if physical signage exists for the path within the station; otherwise, the field will be null.

This change will be introduced into the MBTA's GTFS-static file on **Thursday, December 5, 2019**.