### PR TITLE
fix: add gtfs-realtime docs to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,25 @@
 # MBTA GTFS documentation
-Updated specification extension, archive, and licensing documentation for the MBTA's implementation of the General Transit Feed Specification (GTFS). Developers can follow this repository to stay updated on upcoming changes to the MBTA GTFS feed format.
 
-This repository contains four files:
-* [reference/gtfs.md](https://github.com/mbta/gtfs-documentation/blob/master/reference/gtfs.md) describes the MBTA's implementation of GTFS, supplementing the official GTFS specification by providing local conventions and information about non-standard files and fields.
-* [reference/gtfs-archive.md](https://github.com/mbta/gtfs-documentation/blob/master/reference/gtfs-archive.md) provides information to access archived versions of the GTFS feed for those interested in viewing historical schedules.
-* [developers-license-agreement.pdf](https://github.com/mbta/gtfs-documentation/blob/master/developers-license-agreement.pdf) is the license agreement governing the developers' usage of the MBTA's GTFS feeds.
+Updated specification extension, archive, and licensing documentation for the
+MBTA's implementation of the General Transit Feed Specification (GTFS).
+Developers can follow this repository to stay updated on upcoming changes to the
+MBTA GTFS feed format.
 
-Information on other data available from the MBTA, and resources for developers can be found at the [MBTA Developers page](https://www.mbta.com/developers).
+This repository contains the following files:
+
+* [reference/gtfs.md](reference/gtfs.md) describes the MBTA's implementation of
+  GTFS, supplementing the official GTFS specification with local conventions and
+  information about non-standard files and fields.
+
+* [reference/gtfs-realtime.md](reference/gtfs-realtime.md) describes the MBTA's
+  implementation of the Realtime extensions to GTFS, also known as GTFS-RT.
+
+* [reference/gtfs-archive.md](reference/gtfs-archive.md) provides information on
+  archived versions of the GTFS feed, for those interested in viewing historical
+  schedules.
+
+* [developers-license-agreement.pdf](developers-license-agreement.pdf) is the
+  license agreement governing developers' usage of the MBTA's GTFS feeds.
+
+Information on other data available from the MBTA, and resources for developers
+can be found at the [MBTA Developers page](https://www.mbta.com/developers).


### PR DESCRIPTION
Of course, _immediately_ after merging #29, I realized the README includes a "table of contents" for the files in the repo, and the new `gtfs-realtime.md` was not added to it 😅