### PR TITLE
Add in-seat transfers to transfers.txt

### DIFF
--- a/reference/gtfs.md
+++ b/reference/gtfs.md
@@ -339,14 +339,14 @@ Field Name | GTFS spec | Status | Notes
 ---------- | -------- | ------ | ----------
 from_stop_id | Required | Included | 
 to_stop_id | Required | Included | 
-transfer_type | Required | Included | 
+transfer_type | Required | Included | Includes usage of the [relatively new `4` value](https://github.com/google/transit/blob/master/gtfs/spec/en/reference.md#linked-trips) to link trips between which riders are allowed to remain aboard.
 min_transfer_time | Optional | Included (some records) | As specified in the GTFS standard, this field is the sum of `min_walk_time` and `suggested_buffer_time`.
 min_walk_time | Experimental | Included (some records) | Minimum time required to travel by foot from `from_stop_id` to `to_stop_id`.
 min_wheelchair_time | Experimental | Included (some records) | Minimum time required to travel by wheelchair `from_stop_id` to `to_stop_id`. If the transfer is not wheelchair accessible, this field will be blank.
 suggested_buffer_time | Experimental | Included (some records) | Recommended buffer time to allow to make a successful transfer between two services. This is also partly based on the significance of missing the transfer (due to service frequency).
 wheelchair_transfer | Experimental | Included (some records) | Identifies whether a transfer is accessible to customers using a wheelchair. The field can have the following values:<ul><li>`0` (or empty): indicates that there is no accessibility information for the transfer</li><li>`1`: indicates that the transfer is wheelchair accessible</li><li>`2`: transfer not accessible to persons in wheelchairs</li></ul>
-from_trip_id | Experimental | Included (some records) | If present, specifies that the transfer is exclusively valid from this trip to the trip specified in `to_trip_id`.
-to_trip_id | Experimental | Included (some records) | If present, specifies that the transfer is exclusively valid to this trip from the trip specified in `from_trip_id`.
+from_trip_id | Optional | Included (some records) | If present, specifies that the transfer is exclusively valid from this trip to the trip specified in `to_trip_id`.
+to_trip_id | Optional | Included (some records) | If present, specifies that the transfer is exclusively valid to this trip from the trip specified in `from_trip_id`.
 
 ## trips.txt
 


### PR DESCRIPTION
The primary change in this pull request will be effective in the MBTA's production GTFS file on **Tuesday, September 27, 2022**. This follows from the recent adoption of https://github.com/google/transit/pull/303 into the base GTFS specification.

Summary:
- _transfers.txt_: Support for a new `transfer_type` of `4` is introduced to designate pairs of trips on the same vehicle between which riders are permitted to remain aboard. At this time, `block_id` will remain in use within _trips.txt_ linking trips on the same vehicle regardless of whether riders are permitted to remain aboard.
- _transfers.txt_: `from_trip_id` and `to_trip_id` are now officially part of the base GTFS specification, and are no longer experimental fields.