### PR TITLE
Add feed_id field to feed_info.txt

### DIFF
--- a/reference/gtfs.md
+++ b/reference/gtfs.md
@@ -240,6 +240,7 @@ feed_start_date | Optional | Included | When comparing two GTFS feeds, the newer
 feed_end_date | Optional | Included |
 feed_version | Optional | Included | 
 feed_contact_email | Optional | Included | An email address for communication regarding the GTFS dataset and data publishing practices. It is a technical contact for GTFS-consuming applications. Provide customer service contact information through [agency.txt](agencytxt).
+feed_id | Experimental | Included | The universally unique identifier for the GTFS feed.
 
 ## levels.txt
 


### PR DESCRIPTION
Ticket: [[Extra] 🚝 Add `feed_id` to GTFS](https://app.asana.com/0/584764604969369/1204553929458315/f)

Document the new `feed_id` field, used by the trip planner so that it doesn't auto generate one, which can cause problems if a value is generated that doesn't match the expected value in the dotcom trip planner backend.

See https://github.com/mbta/gtfs_creator/pull/1927