### PR TITLE
feat: Use `fare_media_type=1` for tickets

### DIFF
--- a/reference/gtfs.md
+++ b/reference/gtfs.md
@@ -199,7 +199,7 @@ Field Name | GTFS spec | Status | Notes
 ---------- | -------- | ------ | --------
 fare_media_id | Required | Included | 
 fare_media_name | Optional | Included | 
-fare_media_type | Required | Included | 
+fare_media_type | Required | Included | A `1` value represents a physical, paper ticket that allows a passenger to take either a certain number of pre-purchased trips or unlimited trips within a fixed period of time.
 
 ## fare_products.txt
 


### PR DESCRIPTION
_This change will take effect in the MBTA's GTFS feed beginning on Thursday, 15 June 2023._

### Summary:
- Introduces a value, `1` for the field `fare_media.fare_media_type`, to represent physical, paper tickets. This value will be used for CharlieTickets.